### PR TITLE
RC5 Cipher

### DIFF
--- a/crates/longboy/Cargo.toml
+++ b/crates/longboy/Cargo.toml
@@ -13,9 +13,11 @@ path = "tests/lib.rs"
 
 [dependencies]
 anyhow = "1.0.86"
+cipher = "=0.5.0-pre.4"
 enum-map = "2.7.3"
 flume = "0.11.0"
 fnv = "1.0.7"
+rc5 = { git = "https://github.com/RustCrypto/block-ciphers.git" }
 thunderdome = "0.6.1"
 
 [dev-dependencies]

--- a/crates/longboy/src/proto/cipher.rs
+++ b/crates/longboy/src/proto/cipher.rs
@@ -1,25 +1,45 @@
-pub(crate) struct Cipher<const SIZE: usize> {}
+use cipher::{
+    array::Array,
+    typenum::{U20, U4, U8},
+    BlockCipherDecrypt, BlockCipherEncrypt,
+};
+use rc5::RC5;
+
+pub(crate) struct Cipher<const SIZE: usize>
+{
+    header_cipher: RC5<u16, U20, U8>,
+    slot_cipher: RC5<u32, U20, U8>,
+}
 
 impl<const SIZE: usize> Cipher<SIZE>
 {
     pub(crate) fn new(key: u64) -> Self
     {
-        Self {}
+        Self {
+            header_cipher: RC5::new(key.to_ne_bytes().as_ref()),
+            slot_cipher: RC5::new(key.to_ne_bytes().as_ref()),
+        }
     }
 
     pub(crate) fn encrypt_header(&self, block: &mut [u8; 4])
     {
+        self.header_cipher.encrypt_block(block.as_mut())
     }
 
     pub(crate) fn decrypt_header(&self, block: &mut [u8; 4])
     {
+        self.header_cipher.decrypt_block(block.as_mut())
     }
 
     pub(crate) fn encrypt_slot(&self, block: &mut [u8; SIZE])
     {
+        self.slot_cipher
+            .encrypt_blocks(Array::cast_slice_from_core_mut(block.as_chunks_mut().0))
     }
 
     pub(crate) fn decrypt_slot(&self, block: &mut [u8; SIZE])
     {
+        self.slot_cipher
+            .decrypt_blocks(Array::cast_slice_from_core_mut(block.as_chunks_mut().0))
     }
 }


### PR DESCRIPTION
Non-ideal as I don't see an easy way to adjust the block size for the slots, so it's just fixed to using 8 byte blocks (as I painfully discovered, `block_size = word_size * 2`, hence the word size of `u32`).